### PR TITLE
Fix visibility of unit price in cart display

### DIFF
--- a/assets/js/cart_cn.js
+++ b/assets/js/cart_cn.js
@@ -163,7 +163,7 @@ function updateCartDisplay() {
   
       <div class="flex flex-col flex-1 text-center sm:text-left gap-2">
         <h3 class="font-semibold text-base sm:text-lg text-primary">${item.name_latin}</h3>
-        <p class="text-gray-500 text-sm">单价：<span class="font-medium hidden">${formatPrice(item.price)}</span></p>
+        <p class="text-gray-500 text-sm hidden">单价：<span class="font-medium ">${formatPrice(item.price)}</span></p>
   
         <div class="flex justify-center sm:justify-start items-center gap-2 mt-1">
           <button class="w-8 h-8 bg-gray-200 hover:bg-gray-300 text-xl rounded" onclick="changeQuantity(${index}, -1)">−</button>

--- a/assets/js/cart_en.js
+++ b/assets/js/cart_en.js
@@ -163,7 +163,7 @@ function updateCartDisplay() {
   
       <div class="flex flex-col flex-1 text-center sm:text-left gap-2">
         <h3 class="font-semibold text-base sm:text-lg text-primary">${item.name_latin}</h3>
-        <p class="text-gray-500 text-sm">Unit price : <span class="font-medium hidden">${formatPrice(item.price)}</span></p>
+        <p class="text-gray-500 text-sm hidden">Unit price : <span class="font-medium">${formatPrice(item.price)}</span></p>
   
         <div class="flex justify-center sm:justify-start items-center gap-2 mt-1">
           <button class="w-8 h-8 bg-gray-200 hover:bg-gray-300 text-xl rounded" onclick="changeQuantity(${index}, -1)">−</button>

--- a/assets/js/cart_fr.js
+++ b/assets/js/cart_fr.js
@@ -172,7 +172,7 @@ function updateCartDisplay() {
   
       <div class="flex flex-col flex-1 text-center sm:text-left gap-2">
         <h3 class="font-semibold text-base sm:text-lg text-primary">${item.name_latin}</h3>
-        <p class="text-gray-500 text-sm">Prix Unitaire : <span class="font-medium hidden">${formatPrice(item.price)}</span></p>
+        <p class="text-gray-500 text-sm hidden">Prix Unitaire : <span class="font-medium">${formatPrice(item.price)}</span></p>
   
         <div class="flex justify-center sm:justify-start items-center gap-2 mt-1">
           <button class="w-8 h-8 bg-gray-200 hover:bg-gray-300 text-xl rounded" onclick="changeQuantity(${index}, -1)">−</button>


### PR DESCRIPTION
Moved the 'hidden' class from the price span to the parent paragraph in cart_cn.js, cart_en.js, and cart_fr.js to ensure the unit price is hidden as intended.